### PR TITLE
Fix URLs

### DIFF
--- a/packages/coq:math-comp/coq:math-comp.1.5.0.coq85beta1/url
+++ b/packages/coq:math-comp/coq:math-comp.1.5.0.coq85beta1/url
@@ -1,2 +1,2 @@
-http: "http://ssr.msr-inria.inria.fr/tmp/mathcomp-1.5.coq85beta1.tar.gz"
+http: "http://ssr.msr-inria.inria.fr/FTP/mathcomp-1.5.coq85beta1.tar.gz"
 checksum: "8d40de1e72853d7c04aa4600b9ec6ab2"

--- a/packages/coq:ssreflect/coq:ssreflect.1.5.0.coq85beta1/url
+++ b/packages/coq:ssreflect/coq:ssreflect.1.5.0.coq85beta1/url
@@ -1,2 +1,2 @@
-http: "http://ssr.msr-inria.inria.fr/tmp/ssreflect-1.5.coq85beta1.tar.gz"
+http: "http://ssr.msr-inria.inria.fr/FTP/ssreflect-1.5.coq85beta1.tar.gz"
 checksum: "c682c90a94d2abe2ec6339f0515594ec"

--- a/packages/coqide/coqide.8.5beta1/url
+++ b/packages/coqide/coqide.8.5beta1/url
@@ -1,1 +1,1 @@
-git: "git://github.com/coq/coq#v8.5"
+git: "git://github.com/coq/coq#V8.5beta1"

--- a/packages/coqidetop/coqidetop.8.5beta1/url
+++ b/packages/coqidetop/coqidetop.8.5beta1/url
@@ -1,1 +1,1 @@
-git: "git://github.com/coq/coq#v8.5"
+git: "git://github.com/coq/coq#V8.5beta1"


### PR DESCRIPTION
I fixed the URLs to ssreflect & math-comp and the tagged version of coqidetop (and coqide): without this change, coqidetop does not compile.
